### PR TITLE
Add overlay transitions and intro animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Njorden</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="transition-overlay" class="active"></div>
+    <canvas id="energy-canvas"></canvas>
+    <canvas id="wave-canvas"></canvas>
+    <canvas id="orb-canvas"></canvas>
+    <div class="container hero glass fade-in">
+        <h1 class="title intro delay1">Njorden</h1>
+        <h2 class="subtitle intro delay2">Hydrogen. Heritage. Harmony.</h2>
+        <div class="cta-panel">
+            <a href="our-journey.html" class="btn cta-btn">Follow Our Journey</a>
+        </div>
+    </div>
+    <section class="teaser-section fade-in">
+        <h2>Explore the S1, V1, and M1 Concepts Soon</h2>
+        <div class="silhouettes">
+            <div class="shape"></div>
+            <div class="shape"></div>
+            <div class="shape"></div>
+        </div>
+    </section>
+    <a href="newsletter.html" class="btn newsletter-btn" id="newsletter">Newsletter (Coming Soon)</a>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/journal.html
+++ b/journal.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Journal - Njorden</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="transition-overlay" class="active"></div>
+    <canvas id="energy-canvas"></canvas>
+    <canvas id="wave-canvas"></canvas>
+    <div class="container inner-page glass fade-in">
+        <h1 class="title intro delay1">Journal</h1>
+        <div class="content fade-in">
+            <p>Stay tuned for updates on our progress. Journal entries will appear here as we share the story behind each concept.</p>
+        </div>
+        <a href="our-journey.html" class="btn">Back to Journey</a>
+        <a href="index.html" class="btn">Home</a>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/newsletter.html
+++ b/newsletter.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Newsletter - Njorden</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="transition-overlay" class="active"></div>
+    <canvas id="energy-canvas"></canvas>
+    <canvas id="wave-canvas"></canvas>
+    <div class="container inner-page glass fade-in">
+        <h1 class="title intro delay1">Newsletter</h1>
+        <p>Sign-up coming soon. Stay tuned for updates on Njorden.</p>
+        <a href="index.html" class="btn">Back to Home</a>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/our-journey.html
+++ b/our-journey.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Our Journey - Njorden</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="transition-overlay" class="active"></div>
+    <canvas id="energy-canvas"></canvas>
+    <canvas id="wave-canvas"></canvas>
+    <div class="container inner-page glass fade-in">
+        <h1 class="title intro delay1">Our Journey</h1>
+        <div class="content fade-in">
+            <p>This isn’t just the story of a car company.</p>
+            <p>It’s the beginning of a movement—one that believes true luxury should be clean, quiet, and conscious. Njorden Automotive was born from the Nordic landscape and the myth of Njord, god of wind, sea, and wealth. Our mission is to craft vehicles that honor that spirit: effortless movement, natural harmony, and timeless elegance.</p>
+            <p>We’re building a new kind of car—one that speaks softly but carries deep meaning. Hydrogen-powered. Analogue in soul. Designed for those who want more than status—they want stillness.</p>
+            <h2>Where We Are Now</h2>
+            <p>We’re at the beginning. Our design language is forming. Materials are being sourced. Concepts are in motion. The first prototypes are ahead.</p>
+            <h2>What You Can Expect</h2>
+            <ul>
+                <li>Journal entries documenting each phase of creation</li>
+                <li>Exclusive concept art and behind-the-scenes design thinking</li>
+                <li>Invitations to early viewings, virtual walkthroughs, or founder Q&amp;As</li>
+                <li>A place to witness not just what we’re building—but why</li>
+            </ul>
+            <h2>Be Part of It</h2>
+            <p>Njorden isn’t built in a vacuum. It’s shaped by those who believe in elegance with integrity. Join us—not just as a follower, but as part of a future that flows.</p>
+        </div>
+        <a href="journal.html" class="btn">Visit Our Journal</a>
+        <a href="newsletter.html" class="btn">Newsletter Sign Up</a>
+        <a href="index.html" class="btn">Back to Home</a>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,168 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var overlay = document.getElementById('transition-overlay');
+    var newsletterBtn = document.getElementById('newsletter');
+    if (newsletterBtn) {
+        newsletterBtn.addEventListener('click', function () {
+            alert('Newsletter sign-up coming soon!');
+        });
+    }
+
+    var prefersReduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (!prefersReduce) {
+        initEnergy();
+        initWaves();
+        initOrb();
+    }
+
+    var observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('visible');
+                observer.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+
+    document.querySelectorAll('.fade-in').forEach(function(el) {
+        observer.observe(el);
+    });
+
+    if (overlay) {
+        setTimeout(function () {
+            overlay.classList.remove('active');
+            document.body.classList.add('loaded');
+        }, 400);
+
+        document.querySelectorAll('a[href]').forEach(function(link) {
+            link.addEventListener('click', function (e) {
+                var href = link.getAttribute('href');
+                if (!href || href.startsWith('#') || link.id === 'newsletter') return;
+                if (link.target === '_blank' || e.metaKey || e.ctrlKey) return;
+                e.preventDefault();
+                overlay.classList.add('active');
+                setTimeout(function () {
+                    window.location.href = href;
+                }, 500);
+            });
+        });
+    } else {
+        document.body.classList.add('loaded');
+    }
+});
+
+function initEnergy() {
+    var canvas = document.getElementById('energy-canvas');
+    if (!canvas || !canvas.getContext) return;
+    var ctx = canvas.getContext('2d');
+    function resize() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    var particles = [];
+    for (var i = 0; i < 30; i++) {
+        particles.push({
+            x: Math.random() * canvas.width,
+            y: Math.random() * canvas.height,
+            speed: 0.2 + Math.random() * 0.5,
+            size: 1 + Math.random() * 2
+        });
+    }
+
+    function update() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = 'rgba(111,224,255,0.3)';
+        particles.forEach(function(p) {
+            p.x += p.speed;
+            if (p.x > canvas.width + 20) p.x = -20;
+            ctx.beginPath();
+            ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+            ctx.fill();
+        });
+        requestAnimationFrame(update);
+    }
+    update();
+}
+
+function initWaves() {
+    var canvas = document.getElementById('wave-canvas');
+    if (!canvas || !canvas.getContext) return;
+    var ctx = canvas.getContext('2d');
+    var w, h;
+    var waves = [];
+
+    function resize() {
+        w = canvas.width = window.innerWidth;
+        h = canvas.height = window.innerHeight;
+        waves = [
+            { y: h * 0.3, amp: 20, speed: 0.6, off: Math.random() * Math.PI * 2 },
+            { y: h * 0.5, amp: 25, speed: 0.4, off: Math.random() * Math.PI * 2 },
+            { y: h * 0.7, amp: 30, speed: 0.5, off: Math.random() * Math.PI * 2 }
+        ];
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    function draw() {
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(111,224,255,0.25)';
+        ctx.lineWidth = 2;
+        waves.forEach(function(wv) {
+            wv.off += 0.01 * wv.speed;
+            ctx.beginPath();
+            for (var x = 0; x <= w; x++) {
+                var y = wv.y + Math.sin(x * 0.01 + wv.off) * wv.amp;
+                if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+            }
+            ctx.stroke();
+        });
+        requestAnimationFrame(draw);
+    }
+    draw();
+}
+
+function initOrb() {
+    var canvas = document.getElementById('orb-canvas');
+    if (!canvas || !canvas.getContext) return;
+    var ctx = canvas.getContext('2d');
+
+    function resize() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    var orbs = [];
+    var orbCount = 9;
+    for (var i = 0; i < orbCount; i++) {
+        orbs.push({
+            x: Math.random(),
+            y: Math.random(),
+            base: 30 + Math.random() * 20,
+            t: Math.random() * Math.PI * 2
+        });
+    }
+
+    function draw() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        orbs.forEach(function(o) {
+            o.t += 0.02;
+            var radius = o.base + 10 * Math.sin(o.t);
+            var x = o.x * canvas.width;
+            var y = o.y * canvas.height;
+            var grad = ctx.createRadialGradient(x, y, radius * 0.2, x, y, radius);
+            grad.addColorStop(0, 'rgba(111,224,255,0.8)');
+            grad.addColorStop(1, 'rgba(111,224,255,0)');
+            ctx.fillStyle = grad;
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, Math.PI * 2);
+            ctx.fill();
+        });
+        requestAnimationFrame(draw);
+    }
+    draw();
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,252 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+:root {
+    --color-navy: #0a0f1f;
+    --color-cyan: #6fe0ff;
+    --color-white: #f1f8ff;
+    --color-mist: rgba(255,255,255,0.1);
+}
+
+html, body {
+    height: 100%;
+    margin: 0;
+    font-family: 'Inter', sans-serif;
+    color: var(--color-white);
+}
+
+body {
+    background: var(--color-navy);
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+/* Misty background animation */
+body::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.1), transparent 60%),
+                radial-gradient(circle at 70% 70%, rgba(255,255,255,0.1), transparent 60%),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.05), transparent 60%);
+    animation: drift 20s linear infinite;
+    pointer-events: none;
+    z-index: -1;
+    opacity: 0;
+    filter: blur(10px) brightness(0.6);
+    transition: opacity 1.5s ease, filter 1.5s ease;
+}
+
+body.loaded::before {
+    opacity: 1;
+    filter: blur(0) brightness(1);
+}
+
+#energy-canvas,
+#wave-canvas,
+#orb-canvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: -2;
+}
+
+@keyframes drift {
+    from { transform: translate3d(-25%, -25%, 0) scale(1); }
+    to { transform: translate3d(-50%, -50%, 0) scale(1.5); }
+}
+
+
+.container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    opacity: 0;
+    animation: fadeIn 2s ease-out forwards;
+}
+
+.hero {
+    min-height: 100vh;
+}
+
+.glass {
+    background: rgba(0,0,0,0.4);
+    border: 1px solid var(--color-mist);
+    backdrop-filter: blur(10px);
+    padding: 2rem;
+    border-radius: 10px;
+}
+
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 1s ease-out, transform 1s ease-out;
+}
+
+.fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+
+.title {
+    font-size: 4rem;
+    margin: 0;
+    letter-spacing: 4px;
+}
+
+
+.subtitle {
+    font-size: 1.5rem;
+    margin-top: 0.5rem;
+    letter-spacing: 2px;
+}
+
+
+
+.newsletter-btn {
+    position: fixed;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.cta-section {
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: repeating-linear-gradient(
+        -45deg,
+        rgba(255,255,255,0.05) 0,
+        rgba(255,255,255,0.05) 2px,
+        transparent 2px,
+        transparent 6px
+    );
+    animation: flow 15s linear infinite;
+}
+
+.cta-panel {
+    background: rgba(255,255,255,0.05);
+    backdrop-filter: blur(8px);
+    padding: 1rem 2rem;
+    border-radius: 10px;
+    box-shadow: 0 0 20px rgba(111,224,255,0.15);
+    transition: box-shadow 0.3s ease;
+    margin-top: 1.5rem;
+}
+
+.cta-panel:hover {
+    box-shadow: 0 0 25px rgba(111,224,255,0.4);
+}
+
+.teaser-section {
+    padding: 4rem 1rem;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 80vh;
+}
+
+.teaser-section .silhouettes {
+    display: flex;
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.teaser-section .shape {
+    width: 120px;
+    height: 60px;
+    border-radius: 50% 50% 10% 10%;
+    background: rgba(255,255,255,0.05);
+    filter: blur(6px);
+}
+
+@keyframes flow {
+    from { background-position: 0 0; }
+    to { background-position: 200px 0; }
+}
+
+
+.btn {
+    background: rgba(255,255,255,0.1);
+    border: 1px solid rgba(255,255,255,0.5);
+    color: var(--color-white);
+    padding: 0.75rem 1.5rem;
+    text-decoration: none;
+    margin: 0 0.5rem;
+    transition: background 0.3s ease, box-shadow 0.3s ease;
+    cursor: pointer;
+}
+
+.btn:hover {
+    background: rgba(255,255,255,0.3);
+    box-shadow: 0 0 10px var(--color-cyan);
+}
+
+.intro {
+    opacity: 0;
+    transform: translateY(20px);
+    animation: riseFade 1.5s ease forwards;
+}
+
+.intro.delay2 { animation-delay: 0.6s; }
+.intro.delay1 { animation-delay: 0.3s; }
+
+#transition-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(circle at center, rgba(111,224,255,0.4), rgba(10,15,31,0.9));
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    z-index: 1000;
+}
+
+#transition-overlay.active {
+    opacity: 1;
+}
+
+.cta-btn {
+    font-size: 1.25rem;
+}
+
+.inner-page .title {
+    font-size: 3rem;
+}
+
+
+.inner-page {
+    padding: 4rem 1rem;
+    height: auto;
+    min-height: 100vh;
+    justify-content: flex-start;
+}
+
+.inner-page .content {
+    max-width: 600px;
+    margin: 0 auto 2rem;
+    text-align: left;
+}
+
+.inner-page .btn {
+    margin: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- refine copy to mention **Njorden Automotive** on the journey page
- create a page transition overlay and fade-in intro animations
- add a load animation for the mist background
- include the transition overlay on all pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686aa3ddc32c83319d2dbae0c64d6b4c