### PR TITLE
Provide fallback when JS fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="no-js">
     <div id="transition-overlay" class="active"></div>
     <canvas id="energy-canvas"></canvas>
     <canvas id="wave-canvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
+    document.body.classList.remove('no-js');
     var overlay = document.getElementById('transition-overlay');
     var newsletterBtn = document.getElementById('newsletter');
     if (newsletterBtn) {

--- a/style.css
+++ b/style.css
@@ -96,6 +96,22 @@ body.loaded::before {
     transform: translateY(0);
 }
 
+/* Fallback when JavaScript is unavailable */
+.no-js #transition-overlay {
+    display: none;
+}
+
+.no-js .fade-in {
+    opacity: 1;
+    transform: none;
+}
+
+.no-js .logo {
+    animation: none;
+    opacity: 1;
+    transform: none;
+}
+
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary
- ensure the body defaults to a `no-js` state
- strip the fallback class via JavaScript
- display hero elements when JS is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac6de7730833181ec84193edb0747