### PR TITLE
Remove fade animations and enlarge logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,20 +9,20 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="no-js">
     <div id="transition-overlay" class="active"></div>
     <canvas id="energy-canvas"></canvas>
     <canvas id="wave-canvas"></canvas>
     <canvas id="orb-canvas"></canvas>
-    <div class="container hero glass fade-in">
+    <div class="container hero glass">
         <img src="images/njorden-logo-white.png" alt="Njorden Logo" class="logo">
-        <h1 class="title intro delay1">Njorden</h1>
-        <h2 class="subtitle intro delay2">Hydrogen. Heritage. Harmony.</h2>
+        <h1 class="title">Njorden</h1>
+        <h2 class="subtitle">Hydrogen. Heritage. Harmony.</h2>
         <div class="cta-panel">
             <a href="our-journey.html" class="btn cta-btn">Follow Our Journey</a>
         </div>
     </div>
-    <section class="teaser-section fade-in">
+    <section class="teaser-section">
         <h2>Explore the S1, V1, and M1 Concepts Soon</h2>
         <div class="silhouettes">
             <div class="shape"></div>

--- a/journal.html
+++ b/journal.html
@@ -13,9 +13,9 @@
     <div id="transition-overlay" class="active"></div>
     <canvas id="energy-canvas"></canvas>
     <canvas id="wave-canvas"></canvas>
-    <div class="container inner-page glass fade-in">
-        <h1 class="title intro delay1">Journal</h1>
-        <div class="content fade-in">
+    <div class="container inner-page glass">
+        <h1 class="title">Journal</h1>
+        <div class="content">
             <p>Stay tuned for updates on our progress. Journal entries will appear here as we share the story behind each concept.</p>
         </div>
         <a href="our-journey.html" class="btn">Back to Journey</a>

--- a/newsletter.html
+++ b/newsletter.html
@@ -13,8 +13,8 @@
     <div id="transition-overlay" class="active"></div>
     <canvas id="energy-canvas"></canvas>
     <canvas id="wave-canvas"></canvas>
-    <div class="container inner-page glass fade-in">
-        <h1 class="title intro delay1">Newsletter</h1>
+    <div class="container inner-page glass">
+        <h1 class="title">Newsletter</h1>
         <p>Sign-up coming soon. Stay tuned for updates on Njorden.</p>
         <a href="index.html" class="btn">Back to Home</a>
     </div>

--- a/our-journey.html
+++ b/our-journey.html
@@ -13,9 +13,9 @@
     <div id="transition-overlay" class="active"></div>
     <canvas id="energy-canvas"></canvas>
     <canvas id="wave-canvas"></canvas>
-    <div class="container inner-page glass fade-in">
-        <h1 class="title intro delay1">Our Journey</h1>
-        <div class="content fade-in">
+    <div class="container inner-page glass">
+        <h1 class="title">Our Journey</h1>
+        <div class="content">
             <p>This isn’t just the story of a car company.</p>
             <p>It’s the beginning of a movement—one that believes true luxury should be clean, quiet, and conscious. Njorden Automotive was born from the Nordic landscape and the myth of Njord, god of wind, sea, and wealth. Our mission is to craft vehicles that honor that spirit: effortless movement, natural harmony, and timeless elegance.</p>
             <p>We’re building a new kind of car—one that speaks softly but carries deep meaning. Hydrogen-powered. Analogue in soul. Designed for those who want more than status—they want stillness.</p>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
+    document.body.classList.remove('no-js');
     var overlay = document.getElementById('transition-overlay');
     var newsletterBtn = document.getElementById('newsletter');
     if (newsletterBtn) {
@@ -15,18 +16,6 @@ document.addEventListener('DOMContentLoaded', function () {
         initOrb();
     }
 
-    var observer = new IntersectionObserver(function(entries) {
-        entries.forEach(function(entry) {
-            if (entry.isIntersecting) {
-                entry.target.classList.add('visible');
-                observer.unobserve(entry.target);
-            }
-        });
-    }, { threshold: 0.1 });
-
-    document.querySelectorAll('.fade-in').forEach(function(el) {
-        observer.observe(el);
-    });
 
     if (overlay) {
         setTimeout(function () {

--- a/style.css
+++ b/style.css
@@ -69,8 +69,7 @@ body.loaded::before {
     justify-content: center;
     align-items: center;
     text-align: center;
-    opacity: 0;
-    animation: fadeIn 2s ease-out forwards;
+    opacity: 1;
 }
 
 .hero {
@@ -85,27 +84,11 @@ body.loaded::before {
     border-radius: 10px;
 }
 
-.fade-in {
-    opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 1s ease-out, transform 1s ease-out;
-}
+/* Fallback when JavaScript is unavailable */
 
-.fade-in.visible {
-    opacity: 1;
-    transform: translateY(0);
+.no-js #transition-overlay {
+    display: none;
 }
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes fadeInLogo {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
 
 .title {
     font-size: 4rem;
@@ -124,13 +107,12 @@ body.loaded::before {
 .logo {
     display: block;
     width: 100%;
-    max-width: 150px;
+    max-width: 300px;
     height: auto;
     margin: 0 auto 1rem;
     image-rendering: auto;
-    opacity: 0;
-    transform: translateY(10px);
-    animation: fadeInLogo 1.2s ease forwards;
+    opacity: 1;
+    transform: none;
     transition: filter 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -140,7 +122,7 @@ body.loaded::before {
 
 @media (max-width: 600px) {
     .logo {
-        max-width: 100px;
+        max-width: 150px;
     }
 }
 
@@ -228,14 +210,7 @@ body.loaded::before {
     box-shadow: 0 0 10px var(--color-cyan);
 }
 
-.intro {
-    opacity: 0;
-    transform: translateY(20px);
-    animation: riseFade 1.5s ease forwards;
-}
 
-.intro.delay2 { animation-delay: 0.6s; }
-.intro.delay1 { animation-delay: 0.3s; }
 
 #transition-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- increase the logo size
- remove all fade-in classes and animations
- simplify script.js by dropping the IntersectionObserver
- clean up markup across pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ac6de7730833181ec84193edb0747